### PR TITLE
Fix couldn't find executable

### DIFF
--- a/flycheck-liquidhs.el
+++ b/flycheck-liquidhs.el
@@ -59,7 +59,7 @@
 
 See URL `https://github.com/ucsd-progsys/liquidhaskell'."
        :command
-       ("stack exec liquid" source-inplace)
+       ("stack" "exec" "liquid" source-inplace)
 
        :error-patterns
        (


### PR DESCRIPTION
This fix the problem that flycheck couldn't find the executable.
